### PR TITLE
Renewing and fixing deployment script

### DIFF
--- a/dotnet-core-music-linux/scripts/config-music.sh
+++ b/dotnet-core-music-linux/scripts/config-music.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 # install dotnet core
-sudo sh -c 'echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list'
-sudo apt-key adv --keyserver apt-mo.trafficmanager.net --recv-keys 417A0893
+curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
+sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
+sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-xenial-prod xenial main" > /etc/apt/sources.list.d/dotnetdev.list'
 sudo apt-get update
-sudo apt-get install -y dotnet-dev-1.0.0-preview2-003121
+sudo apt-get install dotnet-dev-1.1.4
 
 # download application
 sudo wget https://raw.github.com/Microsoft/dotnet-core-sample-templates/master/dotnet-core-music-linux/music-app/music-store-azure-demo-pub.tar /

--- a/dotnet-core-music-linux/scripts/config-music.sh
+++ b/dotnet-core-music-linux/scripts/config-music.sh
@@ -17,15 +17,15 @@ sudo apt-get install -y nginx
 sudo service nginx start
 sudo touch /etc/nginx/sites-available/default
 sudo wget https://raw.githubusercontent.com/Microsoft/dotnet-core-sample-templates/master/dotnet-core-music-linux/music-app/nginx-config/default -O /etc/nginx/sites-available/default
-sudo cp /opt/music/nginx-config/default /etc/nginx/sites-available/
+#sudo cp /opt/music/nginx-config/default /etc/nginx/sites-available/
 sudo nginx -s reload
 
 # update and secure music config file
 sed -i "s/<replaceserver>/$1/g" /opt/music/config.json
 sed -i "s/<replaceuser>/$2/g" /opt/music/config.json
 sed -i "s/<replacepass>/$3/g" /opt/music/config.json
-sudo chown $2 /opt/music/config.json
-sudo chmod 0400 /opt/music/config.json
+#sudo chown $2 /opt/music/config.json
+#sudo chmod 0400 /opt/music/config.json
 
 # config supervisor
 sudo apt-get install -y supervisor

--- a/dotnet-core-music-linux/scripts/config-music.sh
+++ b/dotnet-core-music-linux/scripts/config-music.sh
@@ -5,7 +5,7 @@ curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microso
 sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
 sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-xenial-prod xenial main" > /etc/apt/sources.list.d/dotnetdev.list'
 sudo apt-get update
-sudo apt-get install dotnet-dev-1.1.4
+sudo apt-get install -y dotnet-dev-1.1.4
 
 # download application
 sudo wget https://raw.github.com/Microsoft/dotnet-core-sample-templates/master/dotnet-core-music-linux/music-app/music-store-azure-demo-pub.tar /

--- a/dotnet-core-music-linux/scripts/config-music.sh
+++ b/dotnet-core-music-linux/scripts/config-music.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 
+# remove console warnings
+export DEBIAN_FRONTEND=noninteractive
+
 # install dotnet core
 curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
 sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg
 sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-xenial-prod xenial main" > /etc/apt/sources.list.d/dotnetdev.list'
+sudo add-apt-repository universe
 sudo apt-get update
 sudo apt-get install -y dotnet-dev-1.1.4
 
@@ -17,19 +21,15 @@ sudo apt-get install -y nginx
 sudo service nginx start
 sudo touch /etc/nginx/sites-available/default
 sudo wget https://raw.githubusercontent.com/Microsoft/dotnet-core-sample-templates/master/dotnet-core-music-linux/music-app/nginx-config/default -O /etc/nginx/sites-available/default
-#sudo cp /opt/music/nginx-config/default /etc/nginx/sites-available/
 sudo nginx -s reload
 
 # update and secure music config file
 sed -i "s/<replaceserver>/$1/g" /opt/music/config.json
 sed -i "s/<replaceuser>/$2/g" /opt/music/config.json
 sed -i "s/<replacepass>/$3/g" /opt/music/config.json
-#sudo chown $2 /opt/music/config.json
-#sudo chmod 0400 /opt/music/config.json
+sudo chmod 0777 /opt/music/config.json
 
 # config supervisor
-sudo add-apt-repository universe
-sudo apt-get update
 sudo apt-get install -y supervisor
 sudo touch /etc/supervisor/conf.d/music.conf
 sudo wget https://raw.githubusercontent.com/Microsoft/dotnet-core-sample-templates/master/dotnet-core-music-linux/music-app/supervisor/music.conf -O /etc/supervisor/conf.d/music.conf

--- a/dotnet-core-music-linux/scripts/config-music.sh
+++ b/dotnet-core-music-linux/scripts/config-music.sh
@@ -28,6 +28,8 @@ sed -i "s/<replacepass>/$3/g" /opt/music/config.json
 #sudo chmod 0400 /opt/music/config.json
 
 # config supervisor
+sudo add-apt-repository universe
+sudo apt-get update
 sudo apt-get install -y supervisor
 sudo touch /etc/supervisor/conf.d/music.conf
 sudo wget https://raw.githubusercontent.com/Microsoft/dotnet-core-sample-templates/master/dotnet-core-music-linux/music-app/supervisor/music.conf -O /etc/supervisor/conf.d/music.conf


### PR DESCRIPTION
There was a problem with unsupported preview version for dotnet core 1, I have changed it to use Microsoft repository.

Also I am not sure about permissions for the file, but original script was trying to give permissions to the user with DB user name (which does not exist in the system).

Plus there is a small fix to remove warnings from the output about terminal window.

Current version tested on Azure Scale Set on Ubuntu 16.04