### PR TITLE
Update sample to correct deployment issues

### DIFF
--- a/dotnet-core-music-windows/azuredeploy.json
+++ b/dotnet-core-music-windows/azuredeploy.json
@@ -342,8 +342,7 @@
           "name": "config-app",
           "location": "[resourceGroup().location]",
           "dependsOn": [
-            "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'),copyindex())]",
-            "[variables('musicstoresqlName')]"
+            "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'),copyindex())]"
           ],
           "tags": {
             "displayName": "config-app"

--- a/dotnet-core-music-windows/scripts/configure-music-app.ps1
+++ b/dotnet-core-music-windows/scripts/configure-music-app.ps1
@@ -9,6 +9,9 @@ Param (
     [string]$sqlserver
 )
 
+# Force use of TLS 1.2
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
 # Firewall
 netsh advfirewall firewall add rule name="http" dir=in action=allow protocol=TCP localport=80
 
@@ -18,6 +21,7 @@ New-Item -ItemType Directory c:\music
 
 # Install iis
 Install-WindowsFeature web-server -IncludeManagementTools
+
 
 # Install dot.net core sdk
 Invoke-WebRequest http://go.microsoft.com/fwlink/?LinkID=615460 -outfile c:\temp\vc_redistx64.exe


### PR DESCRIPTION
Sample was failing to deploy custom script extension to to improper setting for dependson.  Also script was failing to download sample as it was attempting to use the default tls1.1 which is not supported now.